### PR TITLE
Patch Mousekin Race mod to hide ears under Orassan helmets

### DIFF
--- a/1.5/Patches/Third Party/MousekinRace_Apparel_Patch.xml
+++ b/1.5/Patches/Third Party/MousekinRace_Apparel_Patch.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Mousekin Race</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- Hide Mousekin ears under Orassan helmets -->
+				
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+						defName="Apparel_OrassanSacriArmorHelmet" or
+						defName="Apparel_OrassanPowerArmorHelmet"
+					]/apparel/tags</xpath>
+					<value>
+						<li>Mousekin_HideEars</li>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
As discussed on Discord, Mousekin ears are not supposed to stick out of sealed helmets.

This patch adds the `Mousekin_HideEars` tag to the Orassan power armor helmets, so that the HAR framework will correctly hide the Mousekin's ears when they are worn. 